### PR TITLE
Compatibility with Python 3.10

### DIFF
--- a/autocfg/dataclasses.py
+++ b/autocfg/dataclasses.py
@@ -4,7 +4,7 @@ from typing import *
 import copy
 import json
 import argparse
-from distutils.version import LooseVersion
+from packaging import version
 import warnings
 import yaml
 from dataclasses import dataclass as _dataclass
@@ -161,16 +161,16 @@ def __post_init__(self):
         required_type = field_def.type
         if isinstance(required_type, AnnotateField):
             # check versions
-            auto_version = LooseVersion(self.__auto_version__)
-            added_version = LooseVersion(required_type.added if required_type.added else '0.0')
+            auto_version = version.parse(self.__auto_version__)
+            added_version = version.parse(required_type.added if required_type.added else '0.0')
             if added_version > auto_version:
                 self.__version_annotation__[field_name] = {
                     'mark': 'not_added',
                     'message': f'`{self.__class__}.{field_name}` is not added in version {self.__auto_version__}'
                 }
                 continue
-            deprecated_version = LooseVersion(required_type.deprecated if required_type.deprecated else '999.0')
-            deleted_version = LooseVersion(required_type.deleted if required_type.deleted else '999.0')
+            deprecated_version = version.parse(required_type.deprecated if required_type.deprecated else '999.0')
+            deleted_version = version.parse(required_type.deleted if required_type.deleted else '999.0')
             if deprecated_version <= auto_version < deleted_version:
                 self.__version_annotation__[field_name] = {
                     'mark': 'deprecated',

--- a/autocfg/type_check.py
+++ b/autocfg/type_check.py
@@ -322,6 +322,7 @@ def _instancecheck_type(value, type_):
 
 _SPECIAL_INSTANCE_CHECKERS = {
     'Union': _instancecheck_union,
+    'Optional': _instancecheck_union,
     'Callable': _instancecheck_callable,
     'Type': _instancecheck_type,
     'Any': lambda v, t: True,

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setuptools.setup(
     python_requires='>=3.6',
     install_requires=[
         'pyyaml',
+        'packaging',
         'dataclasses;python_version<"3.7"',
     ],
     tests_require=[

--- a/tests/python/test_dataclass.py
+++ b/tests/python/test_dataclass.py
@@ -14,6 +14,7 @@ class SomeConfig:
     value : Union[TypeC, int, str] = 1
     tup : Tuple = (1, 2, 3)
     no_type = 0.5
+    optional: Union[None, str] = None
 
 @dataclass(version='0.1')
 class TrainConfig:


### PR DESCRIPTION
As it is written here https://docs.python.org/3/library/typing.html#typing.Optional :
> Changed in version 3.10: Optional can now be written as X | None. See [union type expressions](https://docs.python.org/3/library/stdtypes.html#types-union).

This caused problems with the type checker, because it was not compatible with typing.Optional.

Also fixes warnings that `distutils.version` is deprecated by using `packaging.version` instead.